### PR TITLE
Add a check for posts that have media with mixed permissions

### DIFF
--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -108,7 +108,7 @@ def download_media(media):
     id = str(media["id"])
     source = media["source"]["source"]
 
-    if media["type"] != "photo" and media["type"] != "video":
+    if (media["type"] != "photo" and media["type"] != "video") or not media['canView']:
         return
 
     # find extension


### PR DESCRIPTION
A post that has a visible photo but a locked video (for example) would crash the script, as source was None. This change adds a check for view permissions on the media object itself.