### PR TITLE
Move variables out of __main__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 profiles*/
 .idea
+config.json

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ finished downloading content with onlyfans-dl.
 
 ## Updates
 You need to untrack your config file first:
-`git rm config.json`
+`git rm --cached config.json`
 You can then do a pull for updates
 `git pull`
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ DON'T OPEN AN ISSUE ABOUT THE REQUESTS LIBRARY. (
 LOOK: `python -m pip install requests`
 
 ## Usage
-`./onlyfans-dl.py <profile> <accessToken>`
+`./onlyfans-dl.py <profile>`
 * `<profile>` - the username of the profile to download
-* `<accessToken>` - your session's auth token (see below for how to find this)
 
 ## Access Token
 OnlyFans does a bunch of captcha schit in the login, so I wasn't able to automate the login
@@ -32,14 +31,18 @@ process. It's very easy to get your auth token though, here's how:
 
 - Open your browser.
 - After check the value of your User-Agent (you can do this [here](https://whatismybrowser.com/detect/what-is-my-user-agent)),
-copy it, and put it in the value of the `User-Agent` key of `API_HEADER` in `onlyfans-dl.py`.
+copy it, and put it in the value of the `User-Agent` key of `API_HEADER` in `config.json`.
 - Login to OnlyFans as normal.
 - Once you have logged in, open the web console. (Press F12 and click "Console")
 - Type `localStorage.getItem("accessToken");` and press Enter.
 - Copy the string between the quotes, that's your access token.
+- put the access token in the value of the `ACCESS_TOKEN` key in `config.json`
 
 Once you have your access token, don't logout or otherwise end your session until you have
 finished downloading content with onlyfans-dl.
+
+## Updates
+You should be able to just git pull for updates.
 
 ## Contributing
 Please open an issue if you have problems running this.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ Once you have your access token, don't logout or otherwise end your session unti
 finished downloading content with onlyfans-dl.
 
 ## Updates
-You should be able to just git pull for updates.
+You need to untrack your config file first:
+`git rm config.json`
+You can then do a pull for updates
+`git pull`
 
 ## Contributing
 Please open an issue if you have problems running this.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,17 @@
+{
+	"POST_LIMIT": "100",
+	"URL": "https://onlyfans.com",
+	"API_URL": "/api2/v2",
+	"APP_TOKEN": "33d57ade8c02dbc5a333db99ff9ae26a",
+	"USER_INFO": {},
+	"DEBUG": "",
+	"PROFILE": "",
+	"PROFILE_INFO": {},
+	"PROFILE_ID": "",
+	"API_HEADER": {
+		"Accept": "application/json, text/plain, */*",
+		"User-Agent": "put-user-agent-here",
+		"Accept-Encoding": "gzip, deflate"
+	},
+	"ACCESS_TOKEN": "put-token-here"
+}

--- a/config.json
+++ b/config.json
@@ -4,7 +4,6 @@
 	"API_URL": "/api2/v2",
 	"APP_TOKEN": "33d57ade8c02dbc5a333db99ff9ae26a",
 	"USER_INFO": {},
-	"DEBUG": "",
 	"PROFILE": "",
 	"PROFILE_INFO": {},
 	"PROFILE_ID": "",

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
         globals()[i] = config[i]
     
     #print(f"{POST_LIMIT}\n{URL}\n{API_URL}\n{APP_TOKEN}\n{USER_INFO}\n{DEBUG}\n{PROFILE}\n{PROFILE_INFO}\n{PROFILE_ID}\n{API_HEADER}\n{ACCESS_TOKEN}")
-    if ACCESS_TOKEN == "put-token-here" or not ACCESS_TOKEN:
+    if ACCESS_TOKEN == "put-token-here" or not ACCESS_TOKEN or len(sys.argv) != 1:
         
         print("Make sure you configure config.json")
         print("Usage: ./onlyfans-dl <profile>")

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     for i in config.keys():
         globals()[i] = config[i]
     
-    #print(f"{POST_LIMIT}\n{URL}\n{API_URL}\n{APP_TOKEN}\n{USER_INFO}\n{DEBUG}\n{PROFILE}\n{PROFILE_INFO}\n{PROFILE_ID}\n{API_HEADER}\n{ACCESS_TOKEN}")
+    #print(f"{POST_LIMIT}\n{URL}\n{API_URL}\n{APP_TOKEN}\n{USER_INFO}\n{PROFILE}\n{PROFILE_INFO}\n{PROFILE_ID}\n{API_HEADER}\n{ACCESS_TOKEN}")
     if ACCESS_TOKEN == "put-token-here" or not ACCESS_TOKEN:
         
         print("Make sure you configure config.json")

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -109,6 +109,8 @@ def download_public_files():
     public_files = ["avatar", "header"]
     for public_file in public_files:
         source = PROFILE_INFO[public_file]
+        if source is None:
+            continue
         id = get_id_from_path(source)
         file_type = re.findall("\.\w+", source)[-1]
         path = "/" + public_file + "/" + id + file_type
@@ -214,12 +216,12 @@ if __name__ == "__main__":
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n")
 
     # check the access token, pull user info
-
-    API_HEADER["access-token"] = ACCESS_TOKEN
+    
+    API_HEADER["Cookie"] = "sess=" + ACCESS_TOKEN
 
     print("Getting user auth info... ")
 
-    USER_INFO = get_user_info("customer")
+    USER_INFO = get_user_info("me")
     API_HEADER["user-id"] = str(USER_INFO["id"])
 
     print("Getting target profile info...")

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
         print("Existing files will not be re-downloaded.")
 
     assure_dir("profiles")
-    assure_dir(f"profiles/{PROFILE})
+    assure_dir(f"profiles/{PROFILE}")
     assure_dir(f"profiles/{PROFILE}/avatar")
     assure_dir(f"profiles/{PROFILE}/header")
     assure_dir(f"profiles/{PROFILE}/photos")

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -71,9 +71,7 @@ def api_request(endpoint, getdata = None, postdata = None):
                     posts_num = len(list_extend)
                     
                     if posts_num < 100:
-                        break
-
-                    if posts_num < 100:
+                        list_base.extend(list_extend)
                         break
                         
                     # Re-add again the updated beforePublishTime/postedAtPrecise params

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -18,34 +18,24 @@ import base64
 import time
 import datetime as dt
 
-# maximum number of posts to index
-# DONT CHANGE THAT
-POST_LIMIT = "100"
-
-# api info
-URL = "https://onlyfans.com"
-API_URL = "/api2/v2"
-
-#\TODO dynamically get app token
-# Note: this is not an auth token
-APP_TOKEN = "33d57ade8c02dbc5a333db99ff9ae26a"
-
-# user info from /users/customer
+# Initialize variables (Purely cosmetic to stop linters from throwing errors)
+POST_LIMIT = ""
+URL = ""
+API_URL = ""
+APP_TOKEN = ""
 USER_INFO = {}
-
 DEBUG = ""
-
-# target profile
 PROFILE = ""
-# profile data from /users/<profile>
 PROFILE_INFO = {}
 PROFILE_ID = ""
+API_HEADER = {}
+ACCESS_TOKEN = ""
 
-API_HEADER = {
-    "Accept": "application/json, text/plain, */*",
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:86.0) Gecko/20100101 Firefox/86.0",
-    "Accept-Encoding": "gzip, deflate"
-}
+# move dynamic data out of the __main__
+# config.json template added to git and gitignored.
+def parsed_config(filename):
+    with open(f"{filename}",'r') as f:
+        return json.load(f)
 
 # helper function to make sure a dir is present
 def assure_dir(path):
@@ -199,8 +189,18 @@ def download_posts(cur_count, posts, is_archived):
     return cur_count
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("Usage: ./onlyfans-dl <profile> <accessToken>")
+
+    # Parses json to variables
+    # Ignore linters that claim variables are undefined
+    config = parsed_config("config.json")
+    for i in config.keys():
+        globals()[i] = config[i]
+    
+    #print(f"{POST_LIMIT}\n{URL}\n{API_URL}\n{APP_TOKEN}\n{USER_INFO}\n{DEBUG}\n{PROFILE}\n{PROFILE_INFO}\n{PROFILE_ID}\n{API_HEADER}\n{ACCESS_TOKEN}")
+    if ACCESS_TOKEN == "put-token-here" or not ACCESS_TOKEN:
+        
+        print("Make sure you configure config.json")
+        print("Usage: ./onlyfans-dl <profile>")
         print("See README for instructions.")
         exit()
 
@@ -213,7 +213,7 @@ if __name__ == "__main__":
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n")
 
     # check the access token, pull user info
-    API_HEADER["access-token"] = sys.argv[2]
+    API_HEADER["access-token"] = ACCESS_TOKEN
     print("Getting user auth info... ")
 
     USER_INFO = get_user_info("customer")

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -72,14 +72,15 @@ def api_request(endpoint, getdata = None, postdata = None):
                                     params=getparams).json()
                     posts_num = len(list_extend)
 
+                    if posts_num < 100:
+                        break
+                        
                     # Re-add again the updated beforePublishTime/postedAtPrecise params
                     beforePublishTime = list_extend[posts_num-1]['postedAtPrecise']
                     getparams['beforePublishTime'] = beforePublishTime
                     # Merge with previous posts
                     list_base.extend(list_extend)
 
-                    if posts_num < 100:
-                        break
             return list_base
         else:
             return requests.get(URL + API_URL + endpoint,

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -232,18 +232,18 @@ if __name__ == "__main__":
     print("\nonlyfans-dl is downloading content to profiles/" + PROFILE + "!\n")
 
     if os.path.isdir("profiles/" + PROFILE):
-        print("\nProfiles/" + PROFILE + " exists.")
-        print("Media already present will not be re-downloaded.")
+        print(f"\nThe profile {PROFILE} exists.")
+        print("Existing files will not be re-downloaded.")
 
     assure_dir("profiles")
-    assure_dir("profiles/" + PROFILE)
-    assure_dir("profiles/" + PROFILE + "/avatar")
-    assure_dir("profiles/" + PROFILE + "/header")
-    assure_dir("profiles/" + PROFILE + "/photos")
-    assure_dir("profiles/" + PROFILE + "/videos")
-    assure_dir("profiles/" + PROFILE + "/archived")
-    assure_dir("profiles/" + PROFILE + "/archived/photos")
-    assure_dir("profiles/" + PROFILE + "/archived/videos")
+    assure_dir(f"profiles/{PROFILE})
+    assure_dir(f"profiles/{PROFILE}/avatar")
+    assure_dir(f"profiles/{PROFILE}/header")
+    assure_dir(f"profiles/{PROFILE}/photos")
+    assure_dir(f"profiles/{PROFILE}/videos")
+    assure_dir(f"profiles/{PROFILE}/archived")
+    assure_dir(f"profiles/{PROFILE}/archived/photos")
+    assure_dir(f"profiles/{PROFILE}/archived/videos")
 
     # first save profile info
     print("Saving profile info...")

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
         globals()[i] = config[i]
     
     #print(f"{POST_LIMIT}\n{URL}\n{API_URL}\n{APP_TOKEN}\n{USER_INFO}\n{DEBUG}\n{PROFILE}\n{PROFILE_INFO}\n{PROFILE_ID}\n{API_HEADER}\n{ACCESS_TOKEN}")
-    if ACCESS_TOKEN == "put-token-here" or not ACCESS_TOKEN or len(sys.argv) != 1:
+    if ACCESS_TOKEN == "put-token-here" or not ACCESS_TOKEN:
         
         print("Make sure you configure config.json")
         print("Usage: ./onlyfans-dl <profile>")

--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -100,6 +100,8 @@ def get_user_info(profile):
     info = api_request("/users/" + profile).json()
     if "error" in info:
         print("\nERROR: " + info["error"]["message"])
+        print("\nCheck that the script is updated to the latest or that your User-Agent/Access token are correct.")
+        print("\nIf you're still having issues, open an issue: https://github.com/k0rnh0li0/onlyfans-dl/issues/new/choose")
         # bail, we need info for both profiles to be correct
         exit()
     return info


### PR DESCRIPTION
It's better for consistency and management to move dynamic variables outside the main code.
This way git pull won't overwrite user-agent and token, as well it removes the need for sys.argv[x]

All it needs now is:
`$ ./onlyfans-dl <modelname>`