### PR TITLE
Improved message when the directory is already present, fixing the uppercase 

### DIFF
--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -230,7 +230,7 @@ if __name__ == "__main__":
     print("\nonlyfans-dl is downloading content to profiles/" + PROFILE + "!\n")
 
     if os.path.isdir("profiles/" + PROFILE):
-        print("\nProfiles/" + PROFILE + " exists.")
+        print("\nThe folder profiles/" + PROFILE + " exists.")
         print("Media already present will not be re-downloaded.")
 
     assure_dir("profiles")


### PR DESCRIPTION
I've fixed a minor error on the message at line 233 
` print("\nProfiles/" + PROFILE + " exists.")`

Since the directory is **p**rofile with lower p. 👍  