### PR TITLE
Fix all models selection if a one has deactivated

### DIFF
--- a/onlyfans-dl.py
+++ b/onlyfans-dl.py
@@ -406,7 +406,7 @@ if __name__ == "__main__":
         archived_postcount = len(archived_posts)
         if postcount + archived_postcount == 0:
             print("ERROR: 0 posts found.")
-            exit()
+            continue
 
         total_count = postcount + archived_postcount
 


### PR DESCRIPTION
In the cases where a model has deleted all their posts and marked themselves as inactive, we hit the "ERROR: 0 posts found.". which forces an exit. I don't think this is intended behavior as it stops the download all models option from working as we hit the bad model and it force quits.

Changing exit() to continue just moves on to the next model.